### PR TITLE
Create aws-lambda-tools-defaults.json

### DIFF
--- a/aws-lambda-tools-defaults.json
+++ b/aws-lambda-tools-defaults.json
@@ -1,0 +1,19 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "framework": "netcoreapp2.1",
+  "function-runtime": "dotnetcore2.1",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "{{cookiecutter.project_name}}::{{cookiecutter.project_name}}.Function::FunctionHandler"
+}


### PR DESCRIPTION

*Description of changes:*

the [Mock Lambda Test Tool](https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool) which is included in `Aws Lambda Template` in new projects made in visual studio with the aws extensions uses this file to run and execute lambdas locally. Adding this template to the cookie cutter project would help users less familiar with the tool, but still might require some tweaks to the region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

(love the project! cookiecutter is really cool and I really love the SAM)
